### PR TITLE
Update domains to match new locations

### DIFF
--- a/dist/mbed-compile-api.js
+++ b/dist/mbed-compile-api.js
@@ -16,7 +16,7 @@
 }(this, function($) {
     'use strict';
 
-    var defaultApi = "https://developer.mbed.org/api/v2/tasks/compiler/";
+    var defaultApi = "https://build.mbed.com/api/v2/tasks/compiler/";
 
     // Constructor
     var mbedCompileApi = function(logFn, api) {

--- a/example-web.html
+++ b/example-web.html
@@ -41,7 +41,7 @@
         configurator.setCredentials('username', 'password');
 
         // Change this to match your example program
-        var repo = "https://developer.mbed.org/teams/mbed_example/code/Compile_API/"; // URL of repo not in workspace
+        var repo = "https://os.mbed.com/teams/mbed_example/code/Compile_API/"; // URL of repo not in workspace
         var program = "Compile_API"; // name of program in workspace
 
         // Change this to match your platform


### PR DESCRIPTION
@BlackstoneEngineering @naveenkaje 
This PR updates the example to use the new build domain outlined in:

https://os.mbed.com/handbook/Compile-API